### PR TITLE
Fixed obtaining Page Directory pointer for PAE

### DIFF
--- a/CommonTypes/PTE.h
+++ b/CommonTypes/PTE.h
@@ -56,7 +56,10 @@
 
 // 1 << 12 == 4096:
 #define PFN_TO_PAGE(pfn)  ((pfn)  << 12)
-#define PAGE_TO_PFN(page) ((page) >> 12)
+#define PAGE_TO_PFN(page) ((page) >> 12
+
+// CR3 in PAE : PDP at 5:31
+#define PFN_TO_PDP_PAE(pfn) ((pfn) << 5)
 
 #pragma pack(push, 1)
 union VIRTUAL_ADDRESS {

--- a/CommonTypes/PTE.h
+++ b/CommonTypes/PTE.h
@@ -56,7 +56,7 @@
 
 // 1 << 12 == 4096:
 #define PFN_TO_PAGE(pfn)  ((pfn)  << 12)
-#define PAGE_TO_PFN(page) ((page) >> 12
+#define PAGE_TO_PFN(page) ((page) >> 12)
 
 // CR3 in PAE : PDP at 5:31
 #define PFN_TO_PDP_PAE(pfn) ((pfn) << 5)

--- a/Kernel-Bridge/API/PteUtils.cpp
+++ b/Kernel-Bridge/API/PteUtils.cpp
@@ -63,7 +63,7 @@ namespace Pte {
         }
 #else
         if (Cr4.x32.Bitmap.PAE) {
-            PVOID64 PdpePhys = reinterpret_cast<PVOID64>(PFN_TO_PAGE(Cr3.x32.Pae.PDP) + Va.x32.Pae.Generic.PageDirectoryPointerOffset * sizeof(PDPE::x32));
+            PVOID64 PdpePhys = reinterpret_cast<PVOID64>(PFN_TO_PDP_PAE(Cr3.x32.Pae.PDP) + Va.x32.Pae.Generic.PageDirectoryPointerOffset * sizeof(PDPE::x32));
             Info->Pdpe = reinterpret_cast<PDPE*>(GetVirtualForPhysical(PdpePhys));
             if (!Info->Pdpe) return FALSE;
             if (!Info->Pdpe->x32.Pae.Generic.P) return TRUE;


### PR DESCRIPTION
GetPageTables() always fails in x86 PAE because the same shifts amount is used for getting PD pointer from CR3 for both Non-PAE and PAE cases.